### PR TITLE
fix: Use atom in pattern matching of http version

### DIFF
--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -619,7 +619,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     {:ok, "proto"}
   end
 
-  defp transcode?(%{version: "HTTP/1.1"}), do: true
+  defp transcode?(%{version: :"HTTP/1.1"}), do: true
 
   defp transcode?(req) do
     case find_content_type_subtype(req) do

--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -600,6 +600,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     end
   end
 
+  defp extract_subtype("*/*"), do: {:ok, "proto"}
   defp extract_subtype("application/json"), do: {:ok, "json"}
   defp extract_subtype("application/grpc"), do: {:ok, "proto"}
   defp extract_subtype("application/grpc+"), do: {:ok, "proto"}


### PR DESCRIPTION
fix: Allow wildcard content type

- Defaults to proto

fix: Use atom in pattern matching of http version

cowboy:http_version is an atom
